### PR TITLE
增加支持可修改日志中打印的source长度的属性

### DIFF
--- a/config.go
+++ b/config.go
@@ -182,6 +182,7 @@ func xmlToFileLogWriter(filename string, props []XmlProperty, enabled bool) (*Fi
 	daily := false
 	hour := false
 	rotate := false
+	trim_path_cnt := 0
 
 	// Parse properties
 	for _, prop := range props {
@@ -200,6 +201,8 @@ func xmlToFileLogWriter(filename string, props []XmlProperty, enabled bool) (*Fi
 			hour = strings.Trim(prop.Value, " \r\n") != "false"
 		case "rotate":
 			rotate = strings.Trim(prop.Value, " \r\n") != "false"
+		case "trimpathcnt":
+			trim_path_cnt, _ = strconv.Atoi(prop.Value)
 		default:
 			fmt.Fprintf(os.Stderr, "LoadConfiguration: Warning: Unknown property \"%s\" for file filter in %s\n", prop.Name, filename)
 		}
@@ -222,6 +225,7 @@ func xmlToFileLogWriter(filename string, props []XmlProperty, enabled bool) (*Fi
 	flw.SetRotateSize(maxsize)
 	flw.SetRotateDaily(daily)
 	flw.SetRotateHour(hour)
+	flw.SetTrimPathCnt(trim_path_cnt)
 	return flw, true
 }
 

--- a/log4go_test.go
+++ b/log4go_test.go
@@ -136,7 +136,7 @@ func TestFileLogWriter(t *testing.T) {
 	}
 	defer os.Remove(testLogFile)
 
-	w.LogWrite(newLogRecord(CRITICAL, "source", "message"))
+	w.LogWrite(newLogRecord(CRITICAL, "/a/b/c/d/e/b", "message"))
 	w.Close()
 	runtime.Gosched()
 
@@ -503,6 +503,21 @@ func BenchmarkFileLog(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		sl.Log(WARNING, "here", "This is a log message")
+	}
+	b.StopTimer()
+	sl.Close()
+	os.Remove("benchlog.log")
+}
+
+func BenchmarkFileLogTrim(b *testing.B) {
+	sl := make(Logger)
+	b.StopTimer()
+	fileLogW := NewFileLogWriter("benchlog.log", false)
+	fileLogW.trim_path_cnt = 4
+	sl.AddFilter("file", INFO, fileLogW)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sl.Log(WARNING, "/a/b/c/d/e/f/here", "This is a log message")
 	}
 	b.StopTimer()
 	sl.Close()


### PR DESCRIPTION
默认括号中的文件名是全路径的，比如："[2024/07/12 20:44:00.483963] [DEBG] (/a/b/c/d/e/f.go:84) xxxx xxx msg xx"
为了能够缩短打印的长度增加了个新的属性字段trimpathcnt，用来通过从后开始定位到第几个'/'时来缩短打印的长度